### PR TITLE
Add missing OpenCV components to `target_link_libraries()`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ else()
 endif()
 
 
-find_package(OpenCV REQUIRED COMPONENTS core)
+find_package(OpenCV REQUIRED COMPONENTS core imgproc features2d highgui)
 find_package(Eigen3 REQUIRED)
 
 option(BUILD_SHARED_LIBS "build shared libraries" ON)
@@ -102,7 +102,10 @@ set_target_properties(vilib
   )
 
 target_link_libraries(vilib PUBLIC
-  opencv_core Eigen3::Eigen ${CUDA_LIBRARIES})
+  opencv_core opencv_imgproc opencv_features2d opencv_highgui
+  Eigen3::Eigen
+  ${CUDA_LIBRARIES}
+)
 
 # Set different compiler options for cxx and nvcc
 


### PR DESCRIPTION
The library includes symbols from non-core components of OpenCV, which are currently not being explicitly linked against: https://github.com/search?q=repo%3Auzh-rpg%2Fvilib+opencv2+path%3A%2F%5Evisual_lib%5C%2F%2F&type=code

This was causing linker errors when trying to consume the library in this PR: https://github.com/conan-io/conan-center-index/pull/23743